### PR TITLE
Allow to get all configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: node_js
 node_js:
-  - '6.0'
-  - '6.10'
+  - 8
+  - 10
+  - 12
+branches:
+  only:
+    - master

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "serverless-config-generator",
   "version": "1.0.1",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8.10"
   },
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "lint": "standard"
   },
   "dependencies": {
-    "fs-extra": "~3.0.1",
-    "rob-config": "~4.1.1"
+    "fs-extra": "~8.1.0",
+    "rob-config": "~4.2.0"
   },
   "devDependencies": {
     "chai": "^4.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -47,8 +47,10 @@ class ServerlessConfigGeneratorPlugin {
     const envVars = this.getEnvVars(config)
     if (this.options.value) {
       console.log(envVars[this.options.value])
+
       return
     }
+
     console.log(envVars)
   }
 
@@ -75,6 +77,7 @@ class ServerlessConfigGeneratorPlugin {
         ] = `process.env.hasOwnProperty('${propertyName}') ? ${finalPath} : ${value}`
       }
     }
+
     return config
   }
 
@@ -84,11 +87,13 @@ class ServerlessConfigGeneratorPlugin {
     const configVars = this.getEnvVars(config)
     const formattedConfigVars = this.addEnvOverride(configVars, 'process.env.')
     const values = JSON.stringify(formattedConfigVars).replace(/["]+/g, '')
+
     return fs.writeFile(config.configPath, `module.exports = ${values}`)
   }
 
   removeConfigFile() {
     const config = this.getConfig()
+
     return fs.remove(config.configPath).then(_ => {
       this.serverless.cli.log('Removed config file')
     })
@@ -101,6 +106,7 @@ class ServerlessConfigGeneratorPlugin {
 
   getConfig() {
     const { config, processedInput, service } = this.serverless
+
     if (!this.config) {
       const servicePath = config.servicePath || '/'
       const stage = processedInput.options.stage || service.provider.stage
@@ -111,13 +117,16 @@ class ServerlessConfigGeneratorPlugin {
         configPath: path.join(servicePath, CONFIG_FILE_NAME)
       }
     }
+
     return this.config
   }
 
   getEnvVars(config) {
     robConfig.validate()
-    const result = robConfig.get(config.envWorkspace)
-    return result
+
+    return config.envWorkspace
+      ? robConfig.get(config.envWorkspace)
+      : robConfig.getProperties()
   }
 }
 

--- a/test/config/development.js
+++ b/test/config/development.js
@@ -1,6 +1,6 @@
 module.exports = {
-    myService: {
-        port: 3123,
-        public_url: 'http://localhost:8080'
-    }
+  myService: {
+    port: 3123,
+    public_url: 'http://localhost:8080'
+  }
 }

--- a/test/config/schema.js
+++ b/test/config/schema.js
@@ -1,14 +1,21 @@
 module.exports = {
-    myService: {
-        port: {
-            doc: 'The API port',
-            format: 'port',
-            default: 3000
-        },
-        public_url: {
-            doc: 'The public url',
-            format: 'url',
-            default: `http://localhost`
-        }
+  myService: {
+    port: {
+      doc: 'The API port',
+      format: 'port',
+      default: 3000
+    },
+    public_url: {
+      doc: 'The public url',
+      format: 'url',
+      default: `http://localhost`
     }
+  },
+  myOtherService: {
+    identity: {
+      doc: 'The identity name',
+      format: String,
+      default: 'John'
+    }
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -5,65 +5,98 @@ const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider')
 const ConfigGenerator = require('../src')
 
 const configResult = {
+  myService: {
     port: 3123,
     public_url: 'http://localhost:8080'
+  },
+  myOtherService: {
+    identity: 'John'
+  }
 }
 
+const buildServerless = envWorkspace => {
+  const serverless = new Serverless()
+  serverless.service.provider.stage = 'dev'
+  serverless.service.provider.region = 'eu-central-1'
+  if (envWorkspace) {
+    serverless.service.custom.envWorkspace = envWorkspace
+  }
+  serverless.init()
+  serverless.setProvider('aws', new AwsProvider(serverless))
+
+  return serverless
+}
+
+const buildConfigGenerator = (serverless, options) =>
+  new ConfigGenerator(serverless, options)
+
 describe('index.js', () => {
-    let serverless, sandbox, configGenerator
+  let sandbox
 
-    const initConfigGenerator = (options) => {
-        configGenerator = new ConfigGenerator(serverless, options)
-    }
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create()
+  })
 
-    beforeEach(() => {
-        sandbox = sinon.sandbox.create()
+  afterEach(done => {
+    sandbox.restore()
+    done()
+  })
 
-        serverless = new Serverless()
-        serverless.service.provider.stage = 'dev'
-        serverless.service.provider.region = 'eu-central-1'
-        serverless.service.custom.envWorkspace = 'myService'
-        serverless.init()
-        serverless.setProvider('aws', new AwsProvider(serverless))
+  it('should have hooks', () => {
+    const serverless = buildServerless('myService')
+    const configGenerator = buildConfigGenerator(serverless)
+
+    expect(Object.keys(configGenerator.hooks).length).to.not.equal(0)
+  })
+
+  it('should show config variables', () => {
+    const serverless = buildServerless('myService')
+    const configGenerator = buildConfigGenerator(serverless)
+
+    sandbox.stub(configGenerator, 'getEnvVars').callsFake(config => {
+      expect(config.region).to.equal('eu-central-1')
+      expect(config.stage).to.equal('dev')
+      expect(config.envWorkspace).to.equal('myService')
+
+      return configResult.myService
     })
+    sinon.spy(console, 'log')
+    configGenerator.hooks['config-show:show']()
+    expect(configGenerator.getEnvVars.callCount).to.equal(1)
+    expect(console.log.callCount).to.equal(1)
+  })
 
-    afterEach((done) => {
-        sandbox.restore()
-        done()
-    })
+  it('should read rob-config variables', () => {
+    const serverless = buildServerless('myService')
+    const configGenerator = buildConfigGenerator(serverless)
 
-    it('should have hooks', () => {
-        initConfigGenerator()
-        expect(Object.keys(configGenerator.hooks).length).to.not.equal(0)
-    })
+    const config = configGenerator.getConfig()
+    const robConfig = configGenerator.getEnvVars(config)
 
-    it('should show config variables', () => {
-        initConfigGenerator()
-        sandbox.stub(configGenerator, 'getEnvVars').callsFake(config => {
-            expect(config.region).to.equal('eu-central-1')
-            expect(config.stage).to.equal('dev')
-            expect(config.envWorkspace).to.equal('myService')
-            return configResult
-        })
-        sinon.spy(console, 'log')
-        configGenerator.hooks['config-show:show']()
-        expect(configGenerator.getEnvVars.callCount).to.equal(1)
-        expect(console.log.callCount).to.equal(1)
-    })
+    expect(robConfig).to.not.be.null
+    expect(robConfig.port).to.equal(3123)
+    expect(robConfig.public_url).to.equal('http://localhost:8080')
+  })
 
-    it('should read rob-config variables', () => {
-        const config = configGenerator.getConfig()
-        const robConfig = configGenerator.getEnvVars(config)
-        expect(robConfig).to.not.be.null
-        expect(robConfig.port).to.equal(3123)
-        expect(robConfig.public_url).to.equal('http://localhost:8080')
-    })
+  it('should return an error if bad envWorkspace', () => {
+    const serverless = buildServerless('myService')
+    const configGenerator = buildConfigGenerator(serverless)
 
-    it('should return an error if bad envWorkspace', () => {
-        const config = configGenerator.getConfig()
-        config.envWorkspace = 'badWorkspace'
-        expect(configGenerator.getEnvVars.bind(configGenerator, config)).to
-            .throw('cannot find configuration param \'badWorkspace\'')
-    })
+    const config = configGenerator.getConfig()
+    config.envWorkspace = 'badWorkspace'
+    expect(configGenerator.getEnvVars.bind(configGenerator, config)).to.throw(
+      "cannot find configuration param 'badWorkspace'"
+    )
+  })
+
+  it('should read full rob-config variables without envWorkspace', () => {
+    const serverless = buildServerless()
+    const configGenerator = buildConfigGenerator(serverless)
+
+    const config = configGenerator.getConfig()
+    const robConfig = configGenerator.getEnvVars(config)
+
+    expect(robConfig).to.not.be.null
+    expect(robConfig).to.deep.equal(configResult)
+  })
 })
-


### PR DESCRIPTION
Pour un meilleur diff : https://github.com/Next-Interactive/serverless-config-generator/pull/6/files?w=1

## Objectif

Autoriser le plugin à exporter l'intégralité d'un fichier de configuration

## Modification

* [x] LA configuration serverless `service.custom.envWorkspace` devient optionnel
* [x] Mise à jour des dépendances
* [x] Version Nodejs minimum requise : v8.10 et test sur travis avec la version 8, 10 et 12
