### PR TITLE
[BREAKING-CHANGE] Respect rob-config env definition in schema for overiding generatig config

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "fs-extra": "~8.1.0",
+    "lodash.get": "~4.4.2",
     "rob-config": "~4.2.0"
   },
   "devDependencies": {

--- a/test/config/schema.js
+++ b/test/config/schema.js
@@ -3,12 +3,14 @@ module.exports = {
     port: {
       doc: 'The API port',
       format: 'port',
-      default: 3000
+      default: 3000,
+      env: 'API_PORT'
     },
     public_url: {
       doc: 'The public url',
       format: 'url',
-      default: `http://localhost`
+      default: 'http://localhost',
+      env: 'PUBLIC_URL'
     }
   },
   myOtherService: {


### PR DESCRIPTION
Actuellement : on génère des noms de variable d'env dans lesquelles aller chercher la valeur de chaque élément de configuration en fonction du path de la clé de config
Exemple pour: 
```js
{ 
  api: {
    url: {
      default: '',
      env: 'PROJECT_API_URL',
    },
    token: {
      default: '1234'
    }
  }
}
```
La config générée récupère la valeur comme ceci:
```js
{ api: {
   url: process.env.hasOwnProperty('API_URL') ? process.env.API_URL : '',
   token: process.env.hasOwnProperty('API_TOKEN') ? process.env.API_TOKEN : ''
} }
```

A présent, on récupère dans la variable d'environnement uniquement si l'élémént de config defini une clé `env`, en respectant le nom renseigné.
Après, voici la config générée: 
```js
{ api: {
   url: process.env.hasOwnProperty('PROJECT_API_URL') ? process.env.PROJECT_API_URL : ''
   token: '1234'
} }
```
  